### PR TITLE
Fix folder path

### DIFF
--- a/pages/01.gantry5/05.advanced/03.customizing-theme-files/docs.md
+++ b/pages/01.gantry5/05.advanced/03.customizing-theme-files/docs.md
@@ -100,7 +100,7 @@ form:
       label: Background
 ```
 
-The next thing we need to do is create an override of our existing `section.html.twig` file. This file is located in `/media/gantry5/engines/nucleus/templates`. To create an override for this file which won't be overwritten during a theme update, you will want to copy it and paste it in `/templates/TEMPLATE_DIR/custom/engine/templates/layout`. You will need to create the directory path if it doesn't already exist.
+The next thing we need to do is create an override of our existing `section.html.twig` file. This file is located in `/media/gantry5/engines/nucleus/templates/layout`. To create an override for this file which won't be overwritten during a theme update, you will want to copy it and paste it in `/templates/TEMPLATE_DIR/custom/engine/templates/layout`. You will need to create the directory path if it doesn't already exist.
 
 Here is the `section.html.twig` file prior to our changes:
 


### PR DESCRIPTION
The section.html.twig is located in `/media/gantry5/engines/nucleus/templates/layout`, not in `/media/gantry5/engines/nucleus/templates`
