### PR TITLE
There was a error in the text!

### DIFF
--- a/pages/01.gantry5/04.tutorials/05.using-the-font-picker/docs.md
+++ b/pages/01.gantry5/04.tutorials/05.using-the-font-picker/docs.md
@@ -98,7 +98,9 @@ The font selected in this example is `Exo:800`
 Replace `.your-element` with the id(#) or class(.) of the element
 Replace `800` with the selected variation
 
->>> The Roboto and Ubuntu fonts are two of the most complete font sets in the Google Font Library. 
+>>> The Roboto and Ubuntu fonts are two of the most complete font sets in the Google Font Library.
+
+<br>
 
 >>>> Not all of the fonts inside the Google Font Library have variations!
 


### PR DESCRIPTION
Somehow the warning and info labels became connected. I added a < br > to seperate them. I believe it should be alright now according to the preview.
