### PR TITLE
Update Copying Particles to Another Template (Joomla)

### DIFF
--- a/pages/01.gantry5/04.tutorials/14.copying-particles/docs.md
+++ b/pages/01.gantry5/04.tutorials/14.copying-particles/docs.md
@@ -7,7 +7,7 @@ taxonomy:
 
 ## Introduction
 
-Gantry 5 templates are provided with different particles. Not every particle is not included in every Gantry 5 template, sometimes you might want to include a particle from another template into the template that you are using. This tutorial shows you the safe way to copy particles between templates that won't be overwritten again by template updates.
+Gantry 5 templates are provided with different particles. Not every particle is included in every Gantry 5 template, sometimes you might want to include a particle from another template into the template that you are using. This tutorial shows you the safe way to copy particles between templates that won't be overwritten again by template updates.
 
 For the purpose of this tutorial the template you are copying from is the **donor** template and the template you are copying to the **recipient** template.
 


### PR DESCRIPTION
All I did was to remove the word "not" from the sentence at the very top so it made sense.

"Not every particle is **not** included in every Gantry 5 template," so that now it correctly reads as "Not every particle is included in every Gantry 5 template,".
