### PR TITLE
Wrong path to the preset image

### DIFF
--- a/pages/01.gantry5/05.advanced/04.creating-layout-presets/docs.md
+++ b/pages/01.gantry5/05.advanced/04.creating-layout-presets/docs.md
@@ -57,7 +57,7 @@ Here is the example code that will be in our new YAML file:
 version: 2
 
 preset:
-  image: gantry-media://images/admin/layouts/default.png
+  image: gantry-admin://images/layouts/default.png
 
 layout:
   /header/:


### PR DESCRIPTION
Found that the path to the preset image in the example yaml code is wrong. I've corrected, taking it from the default.yaml file
