### PR TITLE
WordPress Platform Settings / Plugin Options

### DIFF
--- a/pages/01.gantry5/02.configure/09.extras/docs.md
+++ b/pages/01.gantry5/02.configure/09.extras/docs.md
@@ -90,7 +90,7 @@ The **Platform Settings** shortcut takes you to a platform-specific settings pag
 [/ui-tab]
 [ui-tab title="WordPress"]
 
-WordPress does not currently have a Platform Settings option as it does not have an equivalent component to that which is present in Joomla.
+You can access these options from the WordPress Plugin Manager > Gantry 5 > Settings or from the Platform Settings option in the Extras Menu.
 
 [/ui-tab]
 [ui-tab title="Grav"]
@@ -103,4 +103,3 @@ You can also remove Gantry from this page.
 
 [/ui-tab]
 [/ui-tabs]
-


### PR DESCRIPTION
Attaching a couple screen shots... WordPress Plugin Settings and the updated Joomla Plugin settings... "Platform Settings" would be where the WordPress info goes in the doc but the old Joomla screen shot is currently under "Alternative Toggle Access" which is a weird section all together... IMO it should be moved to Platform Settings like Grav and WP but it currently routes elsewhere in Joomla... I opened this issue ticket up on that

https://github.com/gantry/gantry5/issues/2010

![wordpress-platform-settings](https://cloud.githubusercontent.com/assets/8940155/26601763/628860b6-453e-11e7-9648-745323e742b0.png)
![joomla-platform-settings](https://cloud.githubusercontent.com/assets/8940155/26601764/6298d702-453e-11e7-9b8b-d2acec827589.png)
