### PR TITLE
Fixed html code for example 2

### DIFF
--- a/pages/01.gantry5/05.advanced/11.responsive-content/docs.md
+++ b/pages/01.gantry5/05.advanced/11.responsive-content/docs.md
@@ -114,9 +114,7 @@ This is a straight forward example of a one row/four column presentation of alte
 ```html
 <div class="g-grid">
     <div class="g-block size-100">
-        <h3 class="center">Free
-            <strong>10 days trial</strong>on all plans. No credit card needed! Need a bigger plan?
-            <a href="#" </a>.</h3>
+        <h3 class="center"><a href="#">Free <strong>10 days trial</strong> on all plans. No credit card needed! Need a bigger plan?</a></h3>
     </div>
 </div>
 <div class="g-grid">


### PR DESCRIPTION
The first `<div>` had a link at the end of the text that wasn't closed with a `>`. Further inspection showed it was an empty link with a `.` at the end which also followed a `?`.

I added the missing `>`, placed the text inside the link, and removed the unnecessary period `.` at the end.