### PR TITLE
Chapter 5.3, fixed wrong paths, added ref to custom overrides

### DIFF
--- a/pages/01.gantry5/05.advanced/03.customizing-theme-files/docs.md
+++ b/pages/01.gantry5/05.advanced/03.customizing-theme-files/docs.md
@@ -26,7 +26,7 @@ In **Hydrogen** the first thing we want to do is add the **Image Picker** to the
 [ui-tabs position="top-left" active="0"]
 [ui-tab title="Joomla"]
 
-To do this, you will need to create an override of the `section.yaml` found in `/media/gantry5/engines/nucleus/admin/blueprints/layout/`. To create the override, you will need to copy this file and paste it to `/TEMPLATE_DIR/custom/engine/admin/blueprints/layout/`.
+To do this, you will need to create an override of the `section.yaml` found in `ROOT/media/gantry5/engines/nucleus/admin/blueprints/layout/`. To create the override, you will need to copy this file and paste it to `/TEMPLATE_DIR/custom/engine/admin/blueprints/layout/`.
 
 [/ui-tab]
 [ui-tab title="WordPress"]
@@ -125,7 +125,7 @@ form:
 [ui-tabs position="top-left" active="0"]
 [ui-tab title="Joomla"]
 
-The next thing we need to do is create an override of our existing `section.html.twig` file. This file is located in `/media/gantry5/engines/nucleus/templates/layout`. To create an override for this file which won't be overwritten during a theme update, you will want to copy it and paste it in `/templates/TEMPLATE_DIR/custom/engine/templates/layout`. You will need to create the directory path if it doesn't already exist.
+The next thing we need to do is create an override of our existing `section.html.twig` file. This file is located in `ROOT/media/gantry5/engines/nucleus/templates/layout`. To create an override for this file which won't be overwritten during a theme update, you will want to copy it and paste it in `/templates/TEMPLATE_DIR/custom/engine/templates/layout`. You will need to create the directory path if it doesn't already exist.
 
 [/ui-tab]
 [ui-tab title="WordPress"]
@@ -332,9 +332,10 @@ The `ROOT/media/gantry5/assets/` directory contains third-party assets used by G
 
 The following directories are rooted in the `ROOT/media/gantry5/engines/nucleus` directory. This directory houses files that belong to the **Nucleus** engine, which is the core of Gantry 5's layout system. It provides core CSS, layout control, core files for theme creation, etc.
 
-When creating custom copies of these files, you will want to put them in `TEMPLATE_DIR/custom/engine/` to indicate that these are engine-specific directories and not part of the theme-specific data.
+When creating custom copies of these files, you will want to put them in `TEMPLATE_DIR/custom/engine/` to indicate that these are engine-specific directories and not part of the theme-specific data. More information on this topic is outline in the [Creating Custom File Overrides](../file-overrides) chapter.
 
 | Directory          |
+|--------------------|
 | :------            |
 | admin/blueprints   |
 | layouts            |
@@ -355,7 +356,7 @@ The `ROOT/wp-content/plugins/gantry5/assets/` directory contains third-party ass
 
 The following directories are rooted in the `ROOT/wp-content/plugins/gantry5/engines/nucleus` directory. This directory houses files that belong to the **Nucleus** engine, which is the core of Gantry 5's layout system. It provides core CSS, layout control, core files for theme creation, etc.
 
-When creating custom copies of these files, you will want to put them in `THEME_DIR/custom/engine/` to indicate that these are engine-specific directories and not part of the theme-specific data.
+When creating custom copies of these files, you will want to put them in `THEME_DIR/custom/engine/` to indicate that these are engine-specific directories and not part of the theme-specific data. More information on this topic is outline in the [Creating Custom File Overrides](../file-overrides) chapter.
 
 | Directory          |
 | :------            |
@@ -378,7 +379,7 @@ The `ROOT/user/plugins/gantry5/assets/` directory contains third-party assets us
 
 The following directories are rooted in the `ROOT/user/plugins/gantry5/engines/nucleus` directory. This directory houses files that belong to the **Nucleus** engine, which is the core of Gantry 5's layout system. It provides core CSS, layout control, core files for theme creation, etc.
 
-When creating custom copies of these files, you will want to put them in `user/data/gantry5/themes/THEME_DIR/engine/` to indicate that these are engine-specific directories and not part of the theme-specific data.
+When creating custom copies of these files, you will want to put them in `user/data/gantry5/themes/THEME_DIR/engine/` to indicate that these are engine-specific directories and not part of the theme-specific data. More information on this topic is outline in the [Creating Custom File Overrides](../file-overrides) chapter.
 
 | Directory          |
 | :------            |

--- a/pages/01.gantry5/05.advanced/03.customizing-theme-files/docs.md
+++ b/pages/01.gantry5/05.advanced/03.customizing-theme-files/docs.md
@@ -378,7 +378,7 @@ The `ROOT/user/plugins/gantry5/assets/` directory contains third-party assets us
 
 The following directories are rooted in the `ROOT/user/plugins/gantry5/engines/nucleus` directory. This directory houses files that belong to the **Nucleus** engine, which is the core of Gantry 5's layout system. It provides core CSS, layout control, core files for theme creation, etc.
 
-When creating custom copies of these files, you will want to put them in `THEME_DIR/engine/` to indicate that these are engine-specific directories and not part of the theme-specific data.
+When creating custom copies of these files, you will want to put them in `user/data/gantry5/themes/THEME_DIR/engine/` to indicate that these are engine-specific directories and not part of the theme-specific data.
 
 | Directory          |
 | :------            |

--- a/pages/01.gantry5/05.advanced/03.customizing-theme-files/docs.md
+++ b/pages/01.gantry5/05.advanced/03.customizing-theme-files/docs.md
@@ -378,7 +378,7 @@ The `ROOT/user/plugins/gantry5/assets/` directory contains third-party assets us
 
 The following directories are rooted in the `ROOT/user/plugins/gantry5/engines/nucleus` directory. This directory houses files that belong to the **Nucleus** engine, which is the core of Gantry 5's layout system. It provides core CSS, layout control, core files for theme creation, etc.
 
-When creating custom copies of these files, you will want to put them in `THEME_DIR/custom/engine/` to indicate that these are engine-specific directories and not part of the theme-specific data.
+When creating custom copies of these files, you will want to put them in `THEME_DIR/engine/` to indicate that these are engine-specific directories and not part of the theme-specific data.
 
 | Directory          |
 | :------            |

--- a/pages/01.gantry5/05.advanced/03.customizing-theme-files/docs.md
+++ b/pages/01.gantry5/05.advanced/03.customizing-theme-files/docs.md
@@ -335,7 +335,6 @@ The following directories are rooted in the `ROOT/media/gantry5/engines/nucleus`
 When creating custom copies of these files, you will want to put them in `TEMPLATE_DIR/custom/engine/` to indicate that these are engine-specific directories and not part of the theme-specific data. More information on this topic is outline in the [Creating Custom File Overrides](../file-overrides) chapter.
 
 | Directory          |
-|--------------------|
 | :------            |
 | admin/blueprints   |
 | layouts            |


### PR DESCRIPTION
Hey there,

I noticed a typo concerning the Grav path for `engine` files under 5.3.

Please see the first screenshot which shows the section with the error ([located here](http://docs.gantry.org/gantry5/advanced/customizing-theme-files#engine-files)) as well as the second screenshot with the correct path ([located here](http://docs.gantry.org/gantry5/advanced/file-overrides#gantry-directory-structure)).

Please carefully compare it with the [file overrides chapter](http://docs.gantry.org/gantry5/advanced/file-overrides#gantry-directory-structure).

**Wrong Path (5.3):**
![grafik](https://user-images.githubusercontent.com/17965908/67529603-e81cd900-f6bc-11e9-8f91-0f296e8956e0.png)

**Correct Path (5.6):**
![grafik](https://user-images.githubusercontent.com/17965908/67529710-36ca7300-f6bd-11e9-90fe-5ba64d27b5e1.png)

Thanks and credits to @ChrystalSolutions who noticed the error as well.

Edit: Additionally I fixed some path inconsistencies and added a reference to chapter 5.6
