### PR TITLE
Updated finder documentation to reflect gantry/gantry5#2561

### DIFF
--- a/pages/01.gantry5/05.advanced/10.content-in-particles/docs.md
+++ b/pages/01.gantry5/05.advanced/10.content-in-particles/docs.md
@@ -172,7 +172,7 @@ Operation is one of: `>`, `>=`, `<`, `<=`, `=`, `BETWEEN`, `NOT BETWEEN`, `IN` a
 
 * `tags` Object that can contain tag `ids` as well as tag `titles`
     * `ids` Either array of tag ids or single id
-    * `titles`Either array of tag titles or a single title
+    * `titles` Either array of tag titles or a single title
 * `matchAll` Set *True* if you want to match an article against all specified tags, *false* if you want to match an article against any passed tag
 
 ```twig

--- a/pages/01.gantry5/05.advanced/10.content-in-particles/docs.md
+++ b/pages/01.gantry5/05.advanced/10.content-in-particles/docs.md
@@ -180,7 +180,7 @@ Operation is one of: `>`, `>=`, `<`, `<=`, `=`, `BETWEEN`, `NOT BETWEEN`, `IN` a
 {% do finder.tags({titles: ['tag1','tag2','tag3']}) %}
 ```
 
-**NOTE:** You can specify both `ids` as well as `titles` when using this routine. Please be aware that the `matchAll` parameter set to `true`will match all tags specified by id or title separately but not collectively.  
+**NOTE:** You can specify both `ids` as well as `titles` when using this routine. Please be aware that the `matchAll` parameter set to `true` will match all tags specified by id or title separately but not collectively.  
 
 # Category Object
 

--- a/pages/01.gantry5/05.advanced/10.content-in-particles/docs.md
+++ b/pages/01.gantry5/05.advanced/10.content-in-particles/docs.md
@@ -168,6 +168,20 @@ Operation is one of: `>`, `>=`, `<`, `<=`, `=`, `BETWEEN`, `NOT BETWEEN`, `IN` a
 {% do finder.category([1,2,3]) %}
 ```
 
+### `.tags(tags, matchAll = false)`
+
+* `tags` Object that can contain tag `ids` as well as tag `titles`
+    * `ids` Either array of tag ids or single id
+    * `titles`Either array of tag titles or a single title
+* `matchAll` Set *True* if you want to match an article against all specified tags, *false* if you want to match an article against any passed tag
+
+```twig
+{% do finder.tags({ids: [1,2,3]}) %}
+{% do finder.tags({titles: ['tag1','tag2','tag3']}) %}
+```
+
+**NOTE:** You can specify both `ids` as well as `titles` when using this routine. Please be aware that the `matchAll` parameter set to `true`will match all tags specified by id or title separately but not collectively.  
+
 # Category Object
 
 Category Object in an category instance with all the fields from the database. You can access the available fields, but there are also some functions to help you.


### PR DESCRIPTION
Hey, I now updated the documentation of `05.advanced` / `10.content-in-particles` to reflect the changes made with PR gantry/gantry5#2561.

I briefly described the usage of the new `finder` method `tags(...)` as well as the parameters. I also added a note which describes how the `matchAll` parameter works. Because it might be confusing as it tackles `ids` and `titles` separately but not collectively. This is the intended behaviour as typically an API user would specify tags as `ids` or `titles` but not mixed - even if it works with the outlined limitation.