### PR TITLE
Updated breakpoint import description, removed old "deprecated" import

### DIFF
--- a/pages/01.gantry5/04.tutorials/10.media-queries/docs.md
+++ b/pages/01.gantry5/04.tutorials/10.media-queries/docs.md
@@ -43,7 +43,7 @@ Using your own media queries can be done very easily within your `custom.scss` f
 
 Below is an example of the code you would add to your `custom.scss` file to enable you to quickly and easily hook in to Gantry 5's breakpoints.
 
-One important line to note is `@import "nucleus/mixins/breakpoints";` which loads the [**_breakpoints.scss**](https://github.com/gantry/gantry5/blob/develop/engines/common/nucleus/scss/nucleus/mixins/_breakpoints.scss) file, making the mixin breakpoint available to use.
+One important line to note is `@import "dependencies";` which loads the `_dependencies.scss` file of the current theme, making the breakpoint mixin defined in [**_breakpoints.scss**](https://github.com/gantry/gantry5/blob/develop/engines/common/nucleus/scss/nucleus/mixins/_breakpoints.scss) available to use. More information on the purpose of the `_dependencies.scss` file is outlined [here](../adding-a-custom-style-sheet#dependenciesscss).
 
 ```scss
 // Gantry 5 custom CSS file
@@ -103,8 +103,6 @@ One important line to note is `@import "nucleus/mixins/breakpoints";` which load
 
 // Mobile Menu Breakpoint
 @media only all and (max-width: $breakpoints-mobile-menu-breakpoint) { ... your css in here ... }
-
-@import "nucleus/mixins/breakpoints";
 ```
 
 Any CSS that you wish to apply to a specific breakpoint can be added inside the appropriate media query above.


### PR DESCRIPTION
@mahagr @RyanMPierson I noticed that under 04./10. there is a wrong description of the import procedure for using breakpoints within SCSS. Additionally there seems to be a leftover from the previous import procedure within the example code. Hence I rewrote the paragraph before the example SCSS to reflect what's really happening. We are not using `@import "nucleus/mixins/breakpoints";` any more within the example so we should not describe the old routine here but rather describe what's happening when using `@import "dependencies"`.

Additionally in the example code below (the last line) there was still the old import lurking around. Which probably was overseen during the docs update. So the description and the below example now clearly reflects what should be done when someone wants to use the breakpoint `mixin` without ambiguity.